### PR TITLE
Add push function that is called from Google Optimize

### DIFF
--- a/js/debug/related_jobs.js
+++ b/js/debug/related_jobs.js
@@ -10,13 +10,19 @@
             .eq(relatedJobsNextItem++)
             .slideDown();
     });
-
-    if(window.optimize !== undefined && window.optimize.relatedJobs === 1){
+    var push = function(enable){
+      if(enable)
         $('[data-related-type="optimized"]')
             .show()
             .find('[data-related-link]:gt('+ (relatedJobsNextItem - 1) + ')')
             .hide();
-    } else {
+      else
         $('[data-related-type="default"]').show();
+
+      appInsights.trackEvent('RecommendedJobs', {'mainJob': JOBCENTRE.ai.mainJob, 'recommendedJobs': JOBCENTRE.ai.recommendedJobs, 'optimized': enable});
     }
+    if(JOBCENTRE.optimize.length === 0)
+      JOBCENTRE.optimize = {push: push};
+    else
+      push(JOBCENTRE.optimize[0]);
 }(jQuery));


### PR DESCRIPTION
Use new method to enable/disable Google Optimize.

@johnnyoshika The new method of enabling Google Optimize/related jobs has some negative consequences.
* Users who use adblock will not see our related jobs
* We need to deploy and enable Google Optimize at around the same time, otherwise no related jobs will appear until it is enabled.